### PR TITLE
MixinExtras Dependency Fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -140,7 +140,7 @@ repositories {
             includeGroup "curse.maven"
         }
     }
-    maven { url 'https://jitpack.io' }
+    mavenCentral()
 }
 
 dependencies {
@@ -149,9 +149,10 @@ dependencies {
     // The userdev artifact is a special name and will get all sorts of transformations applied to it.
     minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
 
-    minecraftLibrary group: "com.github.LlamaLad7", name:"MixinExtras", version: "${mixin_extras_version}"
-    annotationProcessor("com.github.LlamaLad7:MixinExtras:${mixin_extras_version}")
-    jarJar(group: "com.github.LlamaLad7", name:"MixinExtras", version: "[${mixin_extras_version},)")
+    implementation(annotationProcessor("io.github.llamalad7:mixinextras-common:${mixin_extras_version}"))
+    implementation(jarJar("io.github.llamalad7:mixinextras-forge:${mixin_extras_version}")) {
+        jarJar.ranged(it, "[${mixin_extras_version},)")
+    }
 
     annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,5 +9,4 @@ mod_version=1.0.2
 configured_version=4462894
 enchdesc_version=4756855
 bookshelf_version=4771036
-mixin_extras_version=0.1.1
-mixin_extras_next_version=0.2
+mixin_extras_version=0.3.2


### PR DESCRIPTION
Updates the MixinExtras maven and version to fix the odd jar shipping. (The 1.0.2 jar comes with a broken version of MixinExtras, leading it to break unless paired with a mod that has a higher MixinExtras version.)